### PR TITLE
Edit the WunderWay: extended by creating a fork (resolves issue #83)

### DIFF
--- a/about-this-site/how-edit-wunderway.md
+++ b/about-this-site/how-edit-wunderway.md
@@ -101,6 +101,41 @@ You will then be viewing the source of the page on Github. To edit this:
 4. In the same directory, run ``` jekyll serve ```. This compiles the jekyll site and makes it availiable on http://localhost:4000
 5. If you want Jekyll to recompile the site every time you save a file, run ``` jekyll serve --watch ``` instead
 
+### Editing the WunderWay On Your Local Computer by a GitHub fork
+A fork is a copy of the Wunder/WunderWay repository and provides you the freedom to experiment with changes without interfering with the original WunderWay. Only when you are happy with the result, you can ask the owner(s) of the Wunderway to merge your changes by creating a pull request.
+You can also create a fork of the WunderWay. GitHub provides a very profound and crips [tutorial on how to fork](https://help.github.com/articles/fork-a-repo/) a repository. Hence, this section will provide the quick steps to set up your fork and local clone of the WunderWay.
+
+The required steps come down to 
+
+1. Fork the repository.
+2. Make the fix.
+3. Submit a pull request to the project owner.
+
+#### Setup: Forking the WunderWay
+1. Login to your GitHub account
+2. Navigate to the [WunderWay - GitHub Repository](https://github.com/wunderkraut/WunderWay)
+3. Create a fork by clicking on _Fork_ in the top-right corner of the page. This will then create a new repo like ``` https://github.com/YOUR-USER-NAME/WunderWay ```
+4. Clone the fork on your local computer
+
+The WunderWay will further improve and be extended by contributors. Usually, you want to get those changes into your fork, too. Here, it is good practice to sync your fork with the original repository, or _upstream_ in regular intervals. You need to set up the upstream on your local clone:
+
+1. Navigate to the folder of your local clone
+2. Add the upstream by typing ``` $ git remote add upstream https://github.com/wunderkraut/WunderWay.git ``` (note: the original repository is called _upstream_ by convention. But feel free to give it another name and replace _upstream_ by another term.)
+
+#### Editing by branches and pull requests
+You are set up by having a local clone of your GitHub fork. Proceed with these steps to get your commits and pull requests up for reviews:
+
+0. Update your local fork before making any changes by syncing with the upstream
+    1. Make sure that there a no unique commits on your master branch (there should not be any, because all your changes should happen in dedicated branches)
+	  2. Type ``` $ git fetch upstream ```
+	  3. Check out your local master branch ``` $ git checkout gh-pages ```
+	  4. Merge the changes ``` $ git merge upstream/gh-pages ``` (this should trigger a _fast-forward merge_)
+1. Create a new branch, which reflects the issue or your improvement you want to add ``` $ git checkout -b BRANCH_NAME ```
+2. Open an editor of your choice and add your changes
+3. Add and commit the changes ``` $ git commit -am ```
+4. Push your branch to your GitHub repo ``` $ git push ```
+
+Now you only need to let the Expert Group know about your changes by creating a pull request. You create a pull request on GitHub, as described on [GitHub's Pull Request Workflow](https://help.github.com/articles/using-pull-requests/).
 
 ## Reviewing and merging pull requests
 For instructions on how to review and discuss the proposed changes see [Using pull requests.](https://help.github.com/articles/using-pull-requests/#reviewing-proposed-changes)

--- a/about-this-site/how-edit-wunderway.md
+++ b/about-this-site/how-edit-wunderway.md
@@ -132,8 +132,8 @@ You are set up by having a local clone of your GitHub fork. Proceed with these s
 	  4. Merge the changes ``` $ git merge upstream/gh-pages ``` (this should trigger a _fast-forward merge_)
 1. Create a new branch, which reflects the issue or your improvement you want to add ``` $ git checkout -b BRANCH_NAME ```
 2. Open an editor of your choice and add your changes
-3. Add and commit the changes ``` $ git commit -am ```
-4. Push your branch to your GitHub repo ``` $ git push ```
+3. Add and commit the changes ``` $ git commit -am "COMMIT MESSAGE" ```
+4. Push your branch to your GitHub repo ``` $ git push --set-upstream origin BRANCH_NAME ```
 
 Now you only need to let the Expert Group know about your changes by creating a pull request. You create a pull request on GitHub, as described on [GitHub's Pull Request Workflow](https://help.github.com/articles/using-pull-requests/).
 


### PR DESCRIPTION
We have no section explaining how to fork the WunderWay and the required steps to create a pull request when forking the original repository.
I have relied to GitHub's documentation

* https://help.github.com/articles/fork-a-repo/ and
* https://help.github.com/articles/using-pull-requests/

and condensed it to the necessary steps.